### PR TITLE
Remove PurgeCSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ We've tailored this package to our own requirements based on developing a multit
 
 * Craft CMS (with Twigpack)
 * VueJS
-* Tailwind CSS
 
 ### Features
 
@@ -63,7 +62,6 @@ We've tailored this package to our own requirements based on developing a multit
 * [Core JS 3](https://github.com/zloirock/core-js)
 * [Vue Loader](https://vue-loader.vuejs.org/)
 * [Post CSS](https://postcss.org/)
-* [Purge CSS](https://purgecss.com/)
 * Manifest Configuration for use with [Twigpack](https://github.com/nystudio107/craft-twigpack)
 * [State Preserving Hot Reload](https://vue-loader.vuejs.org/guide/hot-reload.html)
 * Build and Development Pipelines
@@ -88,7 +86,7 @@ npm install @batch/craft-webpack -D
 ```json
   "scripts": {
     "dev": "webpack-dev-server --progress --hide-modules --config=node_modules/@batch/craft-webpack/webpack.dev.js",
-    "build": "webpack --progress --hide-modules --config=node_modules/@batch/craft-webpack/webpack.prod.js",
+    "build": "NODE_ENV=production && webpack --progress --hide-modules --config=node_modules/@batch/craft-webpack/webpack.prod.js",
     "dev-legacy": "webpack-dev-server --progress --hide-modules --config=node_modules/@batch/craft-webpack/webpack.dev.js --env.BUILD_TYPE=legacy",
     "dev-combined": "webpack-dev-server --progress --hide-modules --config=node_modules/@batch/craft-webpack/webpack.dev.js --env.BUILD_TYPE=combined"
   }
@@ -114,7 +112,7 @@ If you want to use the legacy or combined build types during development, you us
 
 ### Production
 
-Runs the production pipeline. This will purge CSS and compress the build artifacts ready for sites in production.
+Runs the production pipeline. This will compress the build artifacts ready for sites in production.
 
 ```sh
 npm run build

--- a/package.json
+++ b/package.json
@@ -84,8 +84,6 @@
     "postcss-preset-env": "^6.7.0",
     "postcss-property-lookup": "^2.0.0",
     "postcss-reporter": "^6.0.1",
-    "purgecss-webpack-plugin": "^2.3.0",
-    "purgecss-whitelister": "^2.4.0",
     "resolve-url-loader": "^3.1.1",
     "rimraf": "^3.0.2",
     "stylelint": "^13.7.1",

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -15,9 +15,7 @@ const CompressionPlugin = require("compression-webpack-plugin");
 const ImageminWebpWebpackPlugin = require("imagemin-webp-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
-const PurgecssPlugin = require("purgecss-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
-const WhitelisterPlugin = require("purgecss-whitelister");
 const zopfli = require("@gfx/zopfli");
 
 // config files
@@ -38,14 +36,6 @@ if (fs.existsSync(path.resolve(process.cwd(), 'webpack.config.js'))) {
 rimraf(path.resolve(settings.paths.working, settings.paths.dist.base), {}, () =>
   console.log("\n\nRemoved all previous build assets.\n")
 );
-
-// Custom PurgeCSS extractor for Tailwind that allows special characters in
-// class names.
-//
-// https://github.com/FullHuman/purgecss#extractor
-const TailwindExtractor = (content) => {
-    return content.match(/[A-Za-z0-9-_:\/]+/g) || [];
-}
 
 // Configure Compression webpack plugin
 const configureCompression = () => {
@@ -240,27 +230,6 @@ const configurePostcssLoader = (buildType) => {
   }
 };
 
-// Configure PurgeCSS
-const configurePurgeCss = () => {
-  let paths = [];
-  // Configure whitelist paths
-  for (const [key, value] of Object.entries(settings.purgeCssConfig.paths)) {
-    paths.push(path.join(settings.paths.working, value));
-  }
-
-  return {
-    paths: glob.sync(paths),
-    whitelist: WhitelisterPlugin(settings.purgeCssConfig.whitelist),
-    whitelistPatterns: settings.purgeCssConfig.whitelistPatterns,
-    extractors: [
-      {
-        extractor: TailwindExtractor,
-        extensions: settings.purgeCssConfig.extensions,
-      },
-    ],
-  };
-};
-
 // Configure terser
 const configureTerser = () => {
   return {
@@ -291,7 +260,6 @@ module.exports = [
         path: path.resolve(settings.paths.working, settings.paths.dist.base),
         filename: path.join("./css", "[name].[chunkhash].css"),
       }),
-      new PurgecssPlugin(configurePurgeCss()),
       new CompressionPlugin(configureCompression()),
     ],
   }, projectConfig),

--- a/webpack.settings.js
+++ b/webpack.settings.js
@@ -43,10 +43,4 @@ module.exports = {
   manifestConfig: {
     basePath: "",
   },
-  purgeCssConfig: {
-    paths: ["./templates/**/*.{twig,html}", "./src/vue/**/*.{vue,html}"],
-    whitelist: ["./src/css/components/**/*.{css}"],
-    whitelistPatterns: [],
-    extensions: ["html", "js", "twig", "vue"],
-  },
 };


### PR DESCRIPTION
Resolves #3 

## What I did
I removed all references to PurgeCSS and associated plugins/packages/settings from the webpack config as this is now handled by TailwindCSS by default in the craft-starter project.

## How to test
Run `npm run build`, there shouldn't be any errors.