### PR TITLE
fix: resolve loader paths relative to config

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -26,7 +26,7 @@ const configureBabelLoader = (browserList) => {
     test: /\.js$/,
     exclude: settings.babelLoaderConfig.exclude,
     use: {
-      loader: "babel-loader",
+      loader: require.resolve("babel-loader"),
       options: {
         cacheDirectory: true,
         presets: [
@@ -79,7 +79,7 @@ const configureFontLoader = () => {
     test: /\.(ttf|eot|woff2?)$/i,
     use: [
       {
-        loader: "file-loader",
+        loader: require.resolve("file-loader"),
         options: {
           name: "fonts/[name].[ext]",
         },
@@ -104,7 +104,7 @@ const configureManifest = (fileName) => {
 const configureVueLoader = () => {
   return {
     test: /\.vue$/,
-    loader: "vue-loader",
+    loader: require.resolve("vue-loader"),
   };
 };
 // The base webpack config

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -44,7 +44,7 @@ const configureImageLoader = (buildType) => {
     test: /\.(png|jpe?g|gif|webp)$/i,
     use: [
       {
-        loader: "file-loader",
+        loader: require.resolve("file-loader"),
         options: {
           name: "img/[name].[hash].[ext]",
         },
@@ -61,11 +61,11 @@ const configureSVGLoader = () => {
       {
         oneOf: [
           {
-            loader: "vue-svg-loader",
+            loader: "vuerequire.resolve(-svg-loader"),
           },
           {
             resourceQuery: /^\?external/,
-            loader: "file-loader",
+            loader: require.resolve("file-loader"),
             options: {
               name: "img/[name].[hash].[ext]",
             },
@@ -82,23 +82,23 @@ const configurePostcssLoader = (buildType) => {
     test: /\.(pcss|css)$/,
     use: [
       {
-        loader: "style-loader",
+        loader: require.resolve("style-loader"),
       },
       {
-        loader: "vue-style-loader",
+        loader: "vuerequire.resolve(-style-loader"),
       },
       {
-        loader: "css-loader",
+        loader: require.resolve("css-loader"),
         options: {
           importLoaders: 2,
           sourceMap: true,
         },
       },
       {
-        loader: "resolve-url-loader",
+        loader: "resolverequire.resolve(-url-loader"),
       },
       {
-        loader: "postcss-loader",
+        loader: require.resolve("postcss-loader"),
         options: {
           sourceMap: true,
         },

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -62,7 +62,7 @@ const configureImageLoader = (buildType) => {
       test: /\.(png|jpe?g|gif|webp)$/i,
       use: [
         {
-          loader: "file-loader",
+          loader: require.resolve("file-loader"),
           options: {
             name: "img/[name].[hash].[ext]",
           },
@@ -75,13 +75,13 @@ const configureImageLoader = (buildType) => {
       test: /\.(png|jpe?g|gif|webp)$/i,
       use: [
         {
-          loader: "file-loader",
+          loader: require.resolve("file-loader"),
           options: {
             name: "img/[name].[hash].[ext]",
           },
         },
         {
-          loader: "img-loader",
+          loader: require.resolve("img-loader"),
           options: {
             plugins: [
               require("imagemin-gifsicle")({
@@ -112,11 +112,11 @@ const configureSvgLoader = (buildType) => {
       test: /\.svg$/,
       oneOf: [
         {
-          loader: "vue-svg-loader",
+          loader: require.resolve("vue-svg-loader"),
         },
         {
           resourceQuery: /external/,
-          loader: "file-loader",
+          loader: require.resolve("file-loader"),
           query: {
             name: "img/[name].[hash].[ext]",
           },
@@ -129,19 +129,19 @@ const configureSvgLoader = (buildType) => {
       test: /\.svg$/,
       oneOf: [
         {
-          loader: "vue-svg-loader",
+          loader: require.resolve("vue-svg-loader"),
         },
         {
           resourceQuery: /external/,
           use: [
             {
-              loader: "file-loader",
+              loader: require.resolve("file-loader"),
               query: {
                 name: "img/[name].[hash].[ext]",
               },
             },
             {
-              loader: "img-loader",
+              loader: require.resolve("img-loader"),
               options: {
                 plugins: [
                   require("imagemin-svgo")({
@@ -203,17 +203,17 @@ const configurePostcssLoader = (buildType) => {
       use: [
         MiniCssExtractPlugin.loader,
         {
-          loader: "css-loader",
+          loader: require.resolve("css-loader"),
           options: {
             importLoaders: 2,
             sourceMap: true,
           },
         },
         {
-          loader: "resolve-url-loader",
+          loader: require.resolve("resolve-url-loader"),
         },
         {
-          loader: "postcss-loader",
+          loader: require.resolve("postcss-loader"),
           options: {
             sourceMap: true,
           },
@@ -225,7 +225,7 @@ const configurePostcssLoader = (buildType) => {
   if (buildType === MODERN_CONFIG) {
     return {
       test: /\.(pcss|css)$/,
-      loader: "ignore-loader",
+      loader: require.resolve("ignore-loader"),
     };
   }
 };


### PR DESCRIPTION
Fixes an issue where loaders can’t be resolved as the root project doesn’t have them installed. This ensures loaders are used relative to the webpack config.

References:
- https://github.com/Lyrkan/webpack-encore/commit/a3e1e94342949abf246be4e42b7bae0e3e491dda
- https://stackoverflow.com/questions/52587464/whats-the-purpose-of-using-require-resolve-in-webpack-config-rules
- https://dev.to/stephencweiss/what-is-require-resolve-and-how-does-it-work-1ho4

NZBEX:
<img width="1114" alt="Screen Shot 2020-10-23 at 11 12 06 AM" src="https://user-images.githubusercontent.com/5515179/96935474-9d78ab80-1520-11eb-8fd0-f2bdc0d74ea0.png">