### PR TITLE
feat(webpack.dev.js): update source maps

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -91,7 +91,7 @@ const configurePostcssLoader = (buildType) => {
         loader: require.resolve("css-loader"),
         options: {
           importLoaders: 2,
-          sourceMap: true,
+          sourceMap: false,
         },
       },
       {
@@ -100,7 +100,7 @@ const configurePostcssLoader = (buildType) => {
       {
         loader: require.resolve("postcss-loader"),
         options: {
-          sourceMap: true,
+          sourceMap: false,
         },
       },
     ],
@@ -116,7 +116,7 @@ const legacyConfig = merge(
       publicPath: settings.devServerConfig.public() + "/",
     },
     mode: "development",
-    devtool: "eval-source-map",
+    devtool: "eval-cheap-module-source-map",
     devServer: configureDevServer(LEGACY_CONFIG),
     module: {
       rules: [
@@ -139,7 +139,7 @@ const modernConfig = merge(
       publicPath: settings.devServerConfig.public() + "/",
     },
     mode: "development",
-    devtool: "eval-source-map",
+    devtool: "eval-cheap-module-source-map",
     devServer: configureDevServer(MODERN_CONFIG),
     module: {
       rules: [


### PR DESCRIPTION
## Description

This PR improves dev build performance by turning off CSS source maps and setting JS source maps to use “eval-cheap-source-map”.

Fixes #4  

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I've tested the dev webpack setup locally combined with https://github.com/batchnz/craft/pull/22