### PR TITLE
fix(webpack): stop page reloads on twig file save

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -30,7 +30,14 @@ const configureDevServer = (buildType) => {
     watchContentBase: true,
     watchOptions: {
       poll: !!parseInt(settings.devServerConfig.poll()),
-      ignored: /node_modules/,
+      ignored: [
+        /node_modules/,
+        path.resolve(
+          __dirname,
+          settings.paths.working,
+          settings.paths.templates + "**"
+        ),
+      ],
     },
     headers: {
       "Access-Control-Allow-Origin": "*",


### PR DESCRIPTION
@mikedaviesweb this one is for you [🍺🍺🍺🍺🍺🍺](https://www.threeboysbrewery.co.nz/shop/ipa-rf53r-krkex-b2jk5-7pwz2-m6z4h-lt9xz)

### What I did
A simple change to the dev server `watchOptions-->ignored` setting to prevent the web page from reloading when twig files are saved.

### How to test
1. Run the webpack dev-server and save a twig file. The page should not reload.
2. Save a css/js/vue file and the hot reloading should kick in.

**Note:** A simple way to test is to fire up the craft starter project and replace the contents of `webpack.dev.js` in your `node_modules` with the file from this repo.